### PR TITLE
Feat:결제 비밀번호 수정구현

### DIFF
--- a/src/main/generated/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/entity/QMemberEntity.java
+++ b/src/main/generated/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/entity/QMemberEntity.java
@@ -24,6 +24,8 @@ public class QMemberEntity extends EntityPathBase<MemberEntity> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
+    public final NumberPath<Integer> grade = createNumber("grade", Integer.class);
+
     public final NumberPath<Long> memberId = createNumber("memberId", Long.class);
 
     //inherited

--- a/src/main/java/com/example/TMTBEMemberServer/adaptor/in/web/controller/MemberController.java
+++ b/src/main/java/com/example/TMTBEMemberServer/adaptor/in/web/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.example.TMTBEMemberServer.adaptor.in.web.controller;
 
+import com.example.TMTBEMemberServer.adaptor.in.web.vo.PayPasswordRequestVo;
 import com.example.TMTBEMemberServer.adaptor.in.web.vo.SignUpRequestVo;
+import com.example.TMTBEMemberServer.application.port.in.usecase.PayPasswordUsecase;
 import com.example.TMTBEMemberServer.application.port.in.usecase.RandomNicknameUsecase;
 import com.example.TMTBEMemberServer.application.port.in.usecase.SignUpUsecase;
 import com.example.TMTBEMemberServer.application.port.out.dto.RandomNicknameDto;
@@ -25,6 +27,7 @@ public class MemberController {
     private final ModelMapper modelMapper;
     private final SignUpUsecase signUpUsecase;
     private final RandomNicknameUsecase randomNicknameUsecase;
+    private final PayPasswordUsecase payPasswordUsecase;
     @PostMapping("/signup") //회원가입
     public BaseResponse<Void> SignUp(@RequestBody SignUpRequestVo signUpRequestVo) {
 
@@ -41,6 +44,14 @@ public class MemberController {
         String result = randomNicknameDto.getNickname();
         return new BaseResponse<>(result);
 
+
+    }
+
+    @PostMapping("/pay-password")//결제 비밀번호 설정
+    public BaseResponse<Void> payPassword(@RequestBody PayPasswordRequestVo payPasswordRequestVo) {
+        payPasswordUsecase.payPasswordUpdate(modelMapper.map(payPasswordRequestVo,
+                PayPasswordUsecase.payPasswordRequestDto.class));
+        return new BaseResponse<>();
 
     }
 

--- a/src/main/java/com/example/TMTBEMemberServer/adaptor/in/web/vo/PayPasswordRequestVo.java
+++ b/src/main/java/com/example/TMTBEMemberServer/adaptor/in/web/vo/PayPasswordRequestVo.java
@@ -1,0 +1,17 @@
+package com.example.TMTBEMemberServer.adaptor.in.web.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PayPasswordRequestVo {
+
+    private String payingPassword;
+    private String nickname;
+
+}

--- a/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/entity/MemberEntity.java
+++ b/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/entity/MemberEntity.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Entity
 @Getter
@@ -32,12 +33,13 @@ public class MemberEntity extends BaseEntity {
 
     private String nickname; //닉네임
 
-    @Column(length = 4)
     private String payingPassword; //결제 PW
 
     private String uuid; //uuid
 
     private int status; //회원상태
+
+    private int grade; //회원등급
 
     private String phoneNumber; //전화번호
 
@@ -50,5 +52,6 @@ public class MemberEntity extends BaseEntity {
                 .nickname(signUp.getNickName())
                 .build();
     }
+
 
 }

--- a/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/persistance/PayPasswordAdaptor.java
+++ b/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/persistance/PayPasswordAdaptor.java
@@ -1,0 +1,40 @@
+package com.example.TMTBEMemberServer.adaptor.out.infrastruture.mysql.persistance;
+
+import com.example.TMTBEMemberServer.adaptor.out.infrastruture.mysql.entity.MemberEntity;
+import com.example.TMTBEMemberServer.adaptor.out.infrastruture.mysql.repository.SignUpJpaRepository;
+import com.example.TMTBEMemberServer.application.port.out.outport.SavePayPasswordPort;
+import com.example.TMTBEMemberServer.domain.PayPassword;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PayPasswordAdaptor implements SavePayPasswordPort {
+
+    private final SignUpJpaRepository signUpJpaRepository;
+    public String hashPassword(String Password) { //PW 해시 암호화
+        Password = new BCryptPasswordEncoder().encode(Password);
+        return Password;
+    }
+    @Override
+    @Transactional //결제 패스워드 수정.
+    public void savePayPassword(PayPassword payPassword) {
+        MemberEntity member = signUpJpaRepository.findByNickname(payPassword.getNickname());
+        MemberEntity updatePaypassword = MemberEntity.builder()
+                .memberId(member.getMemberId())
+                .password(member.getPassword())
+                .nickname(member.getNickname())
+                .payingPassword(hashPassword(payPassword.getPayingPassword()))
+                .uuid(member.getUuid())
+                .status(member.getStatus())
+                .grade(member.getGrade())
+                .phoneNumber(member.getPhoneNumber())
+                .build();
+        signUpJpaRepository.save(updatePaypassword);
+    }
+}

--- a/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/persistance/RandomNicknameAdaptor.java
+++ b/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/persistance/RandomNicknameAdaptor.java
@@ -17,8 +17,7 @@ public class RandomNicknameAdaptor implements LoadRandomNicknamePort {
     public Boolean loadRandomNickname(RandomNicknameDto randomNicknameDto) {
         if (signUpJpaRepository.existsByNickname(randomNicknameDto.getNickname())) {
             return true;
-        }
-        return false;
+        }return false;
     }
 
 }

--- a/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/persistance/SignUpAdaptor.java
+++ b/src/main/java/com/example/TMTBEMemberServer/adaptor/out/infrastruture/mysql/persistance/SignUpAdaptor.java
@@ -6,6 +6,7 @@ import com.example.TMTBEMemberServer.application.port.out.dto.SignUpDto;
 import com.example.TMTBEMemberServer.application.port.out.outport.SaveSignUpPort;
 import com.example.TMTBEMemberServer.global.common.exception.CustomException;
 import com.example.TMTBEMemberServer.global.common.response.BaseResponseCode;
+import com.example.TMTBEMemberServer.global.common.response.Grade;
 import com.example.TMTBEMemberServer.global.common.response.State;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +38,9 @@ public class SignUpAdaptor implements SaveSignUpPort {
                 .phoneNumber(signUpDto.getPhoneNumber())
                 .nickname(signUpDto.getNickName())
                 .status(State.SIGNUP.getCode())
+                .grade(Grade.Silver.getCode())
                 .password(hashPassword(signUpDto.getPassword()))
+                .payingPassword("0")
                 .uuid(uuidString)
                 .build();
             signUpJpaRepository.save(member);

--- a/src/main/java/com/example/TMTBEMemberServer/application/port/in/usecase/PayPasswordUsecase.java
+++ b/src/main/java/com/example/TMTBEMemberServer/application/port/in/usecase/PayPasswordUsecase.java
@@ -1,0 +1,23 @@
+package com.example.TMTBEMemberServer.application.port.in.usecase;
+
+import com.example.TMTBEMemberServer.domain.PayPassword;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public interface PayPasswordUsecase {
+
+
+    void payPasswordUpdate(payPasswordRequestDto payPasswordRequestDto);
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    class payPasswordRequestDto{
+        private String nickname;
+        private String payingPassword;
+    }
+
+}

--- a/src/main/java/com/example/TMTBEMemberServer/application/port/out/outport/SavePayPasswordPort.java
+++ b/src/main/java/com/example/TMTBEMemberServer/application/port/out/outport/SavePayPasswordPort.java
@@ -1,0 +1,9 @@
+package com.example.TMTBEMemberServer.application.port.out.outport;
+
+import com.example.TMTBEMemberServer.domain.PayPassword;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface SavePayPasswordPort {
+    @Transactional
+    void savePayPassword(PayPassword payPassword);
+}

--- a/src/main/java/com/example/TMTBEMemberServer/application/service/PayPasswordService.java
+++ b/src/main/java/com/example/TMTBEMemberServer/application/service/PayPasswordService.java
@@ -1,0 +1,21 @@
+package com.example.TMTBEMemberServer.application.service;
+
+import com.example.TMTBEMemberServer.application.port.in.usecase.PayPasswordUsecase;
+import com.example.TMTBEMemberServer.application.port.out.outport.SavePayPasswordPort;
+import com.example.TMTBEMemberServer.domain.PayPassword;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class PayPasswordService implements PayPasswordUsecase {
+
+    private final SavePayPasswordPort payPasswordPort;
+    private final ModelMapper modelMapper;
+    public  void payPasswordUpdate(payPasswordRequestDto payPasswordRequestDto){
+        payPasswordPort.savePayPassword(modelMapper.map(payPasswordRequestDto, PayPassword.class));
+    }
+
+}

--- a/src/main/java/com/example/TMTBEMemberServer/application/service/SignUpService.java
+++ b/src/main/java/com/example/TMTBEMemberServer/application/service/SignUpService.java
@@ -1,6 +1,6 @@
 package com.example.TMTBEMemberServer.application.service;
 
-import com.example.TMTBEMemberServer.adaptor.out.infrastruture.mysql.persistance.SignUpAdaptor;
+
 import com.example.TMTBEMemberServer.application.port.in.usecase.SignUpUsecase;
 import com.example.TMTBEMemberServer.application.port.out.dto.SignUpDto;
 import com.example.TMTBEMemberServer.application.port.out.outport.SaveSignUpPort;
@@ -11,8 +11,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class SignUpService implements SignUpUsecase {
-;
-    private final SignUpAdaptor signUpAdaptor;
+
     private final ModelMapper modelMapper;
     private final SaveSignUpPort saveSignUpPort;
 

--- a/src/main/java/com/example/TMTBEMemberServer/domain/PayPassword.java
+++ b/src/main/java/com/example/TMTBEMemberServer/domain/PayPassword.java
@@ -4,11 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class RandomNickname {
+public class PayPassword {
+
     private String nickname;
+    private String payingPassword;
+
 }

--- a/src/main/java/com/example/TMTBEMemberServer/global/common/response/Grade.java
+++ b/src/main/java/com/example/TMTBEMemberServer/global/common/response/Grade.java
@@ -1,0 +1,24 @@
+package com.example.TMTBEMemberServer.global.common.response;
+
+import lombok.Getter;
+
+@Getter
+public enum Grade {
+
+    Silver(1),//실버 등급
+    Gold(2), //골드 등금
+    Platinum(3),//플레티넘 등급
+    Diamond(4),//다이아몬드 등금
+    Master(5), //마스터등금
+    Challenger(6);//챌린저 등급
+    private final int code;
+
+    Grade(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+}

--- a/src/main/java/com/example/TMTBEMemberServer/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/TMTBEMemberServer/global/config/SecurityConfig.java
@@ -6,13 +6,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig{
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) feat : pull request template#17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링
- [x] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 패키징 구조 변경
- [ ] 파일명 변경
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 결제 비밀번호 암호화 구현 

  <br/>

## 🔎 작업 내용


<!--@{Issue번호} + Enter
ex) @17
이슈와 PR 연결을 위해 사용합니다!-->
- PayPassword 컨트롤러 구현 
- PayPasswordUsecase,Port,Adaptor 구현
- PayPassword 도메인으로 포트 -> 어댑터 전달
- SignUp시 payingpassword default =0(암호화)추가
- 회원등급 enum으로 관리 (Silver,Gold,platinum,diamond,master,challenger)
- 결제 비밀번호 암호화 추가
- paying_password update 구현

  <br/>

